### PR TITLE
Checkout page with report stub and ability to view context of an archival object

### DIFF
--- a/frontend/assets/search_cart.checkout.js
+++ b/frontend/assets/search_cart.checkout.js
@@ -1,0 +1,40 @@
+function CartCheckout(cart, $container, $cartData) {
+  this.cart = cart;
+  this.$container = $container;
+  this.$cartData = $cartData;
+
+  this.loadCart();
+  this.disableCartInToolbar();
+};
+
+
+CartCheckout.prototype.loadCart = function() {
+  var self = this;
+
+  self.$cartData.html(AS.renderTemplate("template_cart_dialog_contents", {
+    selected: self.cart.data
+  }));
+
+  self.cart.bindSummaryEvents(self.$container);
+  self.$container.on("click", ".clear-cart-btn", function() {
+    self.cart.clearSelection();
+    location.reload();
+  });
+
+  self.$container.on("click", "#generateReportFromCart", function() {
+    alert("Next on the list!");
+  });
+}
+
+
+CartCheckout.prototype.disableCartInToolbar = function() {
+  this.cart.$cart.find(":input").attr("disabled", "disabled").addClass("disabled");
+};
+
+$(function() {
+  if (typeof AS.Cart == "undefined") {
+    return;
+  }
+
+  new CartCheckout(AS.Cart, $("#cartCheckoutPane"), $("#cartData"));
+});

--- a/frontend/assets/search_cart.css
+++ b/frontend/assets/search_cart.css
@@ -16,3 +16,65 @@ table .table-record-actions .btn-group {
   margin-top: 4px;
   width: 100%;
 }
+
+#cartCheckoutPane #cartData {
+    min-height: 200px;
+}
+
+#cartSummaryDropdownPanel {
+  padding: 10px;
+}
+
+#cartSummaryDropdownPanel a {
+  width: 100%;
+}
+
+#generateReportFromCart {
+  width: 100%;
+}
+
+#cartCheckoutPane .as-nav-list {
+  box-shadow: none;
+}
+
+.cart-preview .extra-context {
+    margin: 10px 20px;
+    border-top: 1px dotted #DDD;
+    padding: 10px 0 0;
+}
+
+.cart-preview .extra-context ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.cart-preview .extra-context ul li {
+    padding: 0;
+    clear: both;
+}
+
+.cart-preview .extra-context ul ul li .tree-icon {
+    background-image: url("jstree/d.png");
+    background-repeat: no-repeat;
+    background-color: transparent;
+    background-position: -36px 0;
+    width: 16px;
+    height: 16px;
+    display: inline-block;
+}
+
+.cart-preview .extra-context ul ul ul li {
+    padding-left: 16px;
+}
+
+.cart-preview .extra-context .tree-icon,
+.cart-preview .extra-context .asicon {
+    float: left;
+    margin: 0 5px 0 0;
+}
+
+.cart-preview .extra-context strong {
+    display: inline-block;
+    width: 90%;
+}

--- a/frontend/controllers/cart_controller.rb
+++ b/frontend/controllers/cart_controller.rb
@@ -1,0 +1,18 @@
+class CartController < ApplicationController
+
+  skip_before_filter :unauthorised_access
+
+  def checkout
+  end
+
+  def extra_context
+    @ao = JSONModel(:archival_object).find(JSONModel(:archival_object).id_for(params[:uri]))
+    @tree = JSONModel(:resource_tree).find(nil,
+                                   :resource_id => JSONModel(:resource).id_for(@ao['resource']['ref']),
+                                   :limit_to => params[:uri])
+
+    render_aspace_partial :partial => "cart/context"
+  end
+
+end
+

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -1,6 +1,8 @@
 en:
   cart:
-    cart_dialog_title: Your Cart
-    cart_clear_selection_button: Empty Cart
+    your_cart: Your Cart
+    cart_clear_selection_button: Empty the Cart
     add_action: Add
     remove_action: Remove
+    checkout: Checkout
+    loading: Loading your cart...

--- a/frontend/plugin_init.rb
+++ b/frontend/plugin_init.rb
@@ -1,3 +1,6 @@
+my_routes = [File.join(File.dirname(__FILE__), "routes.rb")]
+ArchivesSpace::Application.config.paths['config/routes'].concat(my_routes)
+
 Rails.application.config.after_initialize do
 
 
@@ -11,23 +14,17 @@ Rails.application.config.after_initialize do
 
 
   ActionView::PartialRenderer.class_eval do
-     # module ClassMethods
-        alias_method :render_pre_search_cart, :render
-        def render(context, options, block)
-          p "**"
-          p options
+    alias_method :render_pre_search_cart, :render
+    def render(context, options, block)
+      result = render_pre_search_cart(context, options, block);
 
-          result = render_pre_search_cart(context, options, block);
+      # Add our cart-specific templates to shared/templates
+      if options[:partial] == "shared/templates"
+        result += render(context, options.merge(:partial => "search/cart"), nil)
+      end
 
-          # Add our cart-specific templates to shared/templates
-          if options[:partial] == "shared/templates"
-            result += render(context, options.merge(:partial => "search/cart"), nil)
-          end
-
-          result
-        end
-    #  end
-    # end
+      result
+    end
   end
 
 end

--- a/frontend/routes.rb
+++ b/frontend/routes.rb
@@ -1,0 +1,4 @@
+ArchivesSpace::Application.routes.draw do
+  match('/plugins/search_cart/checkout' => 'cart#checkout', :via => [:get])
+  match('/plugins/search_cart/context' => 'cart#extra_context', :via => [:get])
+end

--- a/frontend/views/cart/_checkout_details.html.erb
+++ b/frontend/views/cart/_checkout_details.html.erb
@@ -1,0 +1,50 @@
+<% @expanded[:records_by_type].each do |type, records| %>
+  <% if ['resource', 'archival_object'].include?(type)
+      next
+     end %>
+  <h3><%= I18n.t("#{type}._plural") %></h3>
+
+  <ul>
+    <% records.each do |record| %>
+      <li>
+        <strong><%= record['display_string'] || record['title'] %></strong>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
+<% if !@expanded[:component_trees].blank? %>
+
+  <% render_tree_node = lambda do |node| %>
+    <% selected = @uris.include?(node['record_uri']) %>
+    <% if !selected && node['children'].blank?
+         next
+       end
+    %>
+    <li>
+      <% if selected %>
+        <strong><%= node['title'] %></strong>
+      <% else %>
+        <%= node['title'] %>
+      <% end %>
+
+      <% if !node['children'].blank? %>
+        <ul>
+          <% node['children'].each do |child| %>
+            <% render_tree_node.call(child) %>
+          <% end %>
+        </ul>
+      <% end %>
+    </li>
+  <% end %>
+
+  <h3><%= I18n.t("resource._plural") %> &amp; <%= I18n.t("archival_object._plural") %></h3>
+  <ul>
+    <% @expanded[:component_trees].each do |_, resource| %>
+      <% render_tree_node.call(resource) %>
+    <% end %>
+  </ul>
+<% end %>
+
+<pre class="hide"><%= @expanded[:component_trees].inspect %></pre>
+<pre class="hide"><%= @cart.inspect %></pre>

--- a/frontend/views/cart/_context.html.erb
+++ b/frontend/views/cart/_context.html.erb
@@ -1,0 +1,30 @@
+<% render_node = lambda do |node|%>
+  <% selected = @ao.uri == node['record_uri'] %>
+  <%
+     if !selected && node['children'].blank?
+       next
+     end
+  %>
+  <li>
+    <span class="tree-icon"></span>
+    <span class="asicon icon-<%= node['node_type'] %>"></span>
+    <% if selected %>
+      <strong><%= node['title'] %></strong>
+    <% else %>
+      <%= node['title'] %>
+
+      <% unless node['children'].blank? %>
+        <ul>
+          <% node['children'].each do |child| %>
+            <% render_node.call(child) %>
+          <% end %>
+        </ul>
+      <% end %>
+
+    <% end %>
+  </li>
+<% end %>
+
+<ul>
+  <% render_node.call(@tree) %>
+</ul>

--- a/frontend/views/cart/checkout.html.erb
+++ b/frontend/views/cart/checkout.html.erb
@@ -1,0 +1,45 @@
+<%= setup_context(:title => I18n.t("cart.checkout")) %>
+
+<div id="cartCheckoutPane" class="row">
+  <div class="col-md-3">
+    <div class="as-nav-list affix" data-spy="affix">
+      <hr>
+
+      <fieldset>
+        <div class="form-group">
+          <label class="control-label">Report Format</label>
+          <select class="form-control" id="report_format" name="report_format">
+            <option>HTML</option>
+            <option>JSON</option>
+            <option>PDF</option>
+            <option>CSV</option>
+          </select>
+        </div>
+      </fieldset>
+
+      <hr>
+
+      <p>
+        <button id="generateReportFromCart" class="btn btn-primary">Generate Report</button>
+      </p>
+    </div>
+  </div>
+  <div class="col-md-9">
+    <div class="record-pane">
+      <button class="btn btn-warning clear-cart-btn pull-right"><%= I18n.t("cart.cart_clear_selection_button") %></button>
+
+      <h2><%= I18n.t("cart.your_cart") %></h2>
+
+      <%= render_aspace_partial :partial => "shared/flash_messages" %>
+
+      <div id="cartData">
+        <div class="alert alert-info">
+          <%= I18n.t("cart.loading") %>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<script src="<%= "#{AppConfig[:frontend_prefix]}assets/search_cart.checkout.js" %>"></script>

--- a/frontend/views/search/_cart.html.erb
+++ b/frontend/views/search/_cart.html.erb
@@ -5,51 +5,62 @@
         <span class="glyphicon glyphicon-shopping-cart"></span>
         <span class="badge cart-count"></span>
       </button>
-
+      <div class=btn-group>
+        <button class="btn btn-default navbar-btn dropdown-toggle" data-toggle="dropdown">
+          <span class="caret"></span>
+        </button>
+        <div id="cartSummaryDropdownPanel" class="dropdown-menu pull-right">
+          <%= link_to I18n.t("cart.checkout"), {:controller => :cart, :action => :checkout}, {:class => "btn btn-primary"} %>
+        </div>
+      </div>
     </div>
   </li>
 --></div>
 
 <div id="template_cart_dialog_title"><!--
-  <%= I18n.t("cart.cart_dialog_title") %>
+  <%= I18n.t("cart.your_cart") %>
 --></div>
 
-<!-- <p>
-
-    </p>-->
-
 <div id="template_cart_dialog_contents"><!--
-  <div class="cart-preview">
-    <table class="table table table-striped table-bordered table-condensed table-hover token-list">
-      <thead>
-        <tr>
-          <th></th>
-          <th>
-            <button class="btn btn-xs btn-warning clear-cart-btn pull-right"><%= I18n.t("cart.cart_clear_selection_button") %></button>
-          </th>
+  {if ($.isEmptyObject(selected))}
+    <div class="alert alert-info">Cart is empty</div>
+  {else}
+    <div class="cart-preview">
+      <table class="table table table-striped table-bordered table-condensed table-hover token-list">
+        <tbody>
+      {for record in selected}
+        <tr data-uri="${record.uri}">
+          <td>
+            <div class="${record.record_type}">
+              <span class="icon-token"></span> ${record.display_string}
+            </div>
+            <div class="extra-context" style="display:none"></div>
+          </td>
+          <td>
+            <div class="btn-group pull-right">
+              {if record.record_type == 'archival_object'}
+              <button class="btn btn-xs btn-default expand-context-btn">
+                <span class="glyphicon glyphicon-screenshot"></span>
+              </button>
+              {/if}
+              <button class="btn btn-xs btn-warning remove-from-cart-btn">
+                <span class="glyphicon glyphicon-remove"></span>
+              </button>
+            </div>
+          </td>
         </tr>
-      </thead>
-      <tbody>
-    {for record in selected}
-      <tr data-uri="${record.uri}">
-        <td>
-          <div class="${record.record_type}">
-            <span class="icon-token"></span> ${record.display_string}
-          </div>
-        </td>
-        <td>
-          <button class="btn btn-xs btn-warning remove-from-cart-btn pull-right"><span class="glyphicon glyphicon-shopping-cart"></span> <%= I18n.t("cart.remove_action") %></button>
-        </td>
-      </tr>
-    {/for}
-      </tbody>
-    </table>
-  </div>
+      {/for}
+        </tbody>
+      </table>
+    </div>
+  {/if}
 --></div>
 
 <div id="template_cart_dialog_footer"><!--
 <div class="modal-footer">
+  <%= link_to I18n.t("cart.checkout"), {:controller => :cart, :action => :checkout}, {:class => "btn btn-primary pull-left"} %>
   <button class="btn btn-default pull-right" data-dismiss="modal"><%= I18n.t("actions.close") %></button>
+  <button class="btn btn-warning pull-right clear-cart-btn" data-dismiss="modal"><%= I18n.t("cart.cart_clear_selection_button")  %></button>
 </div>
 --></div>
 
@@ -58,7 +69,7 @@
   <button class="btn btn-xs btn-warning remove-from-cart-btn hide"><span class="glyphicon glyphicon-shopping-cart"></span> <%= I18n.t("cart.remove_action") %></button>
 --></div>
 
-<% if current_user %>
+<% if current_user && current_repo %>
 <script>
   var CURRENT_REPO_URI = '<%= current_repo.uri %>'
 </script>


### PR DESCRIPTION
Introduce a checkout page with a stub for generating a report from the selected items. Also allow for users to view the hierarchy for archival objects to provide a better context of those records.  This context is loaded in dynamically when the 'target' icon is clicked (available from both the cart dialog and checkout page).
