### PR TITLE
Make Archival Object 'level' more visible in searches

### DIFF
--- a/backend/model/archival_object_ext.rb
+++ b/backend/model/archival_object_ext.rb
@@ -1,0 +1,1 @@
+ArchivalObject.include(LevelDisplayString)

--- a/backend/model/mixins/level_display_string.rb
+++ b/backend/model/mixins/level_display_string.rb
@@ -1,0 +1,23 @@
+module LevelDisplayString
+
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  def level_display_string
+    self.other_level || I18n.t("enumerations.archival_record_level.#{self.level}", self.level)
+  end
+
+  module ClassMethods
+    def sequel_to_jsonmodel(objs, opts = {})
+      jsons = super
+
+      jsons.zip(objs).each do |json, obj|
+        json['level_display_string'] = obj.level_display_string
+      end
+
+      jsons
+    end
+  end
+
+end

--- a/frontend/plugin_init.rb
+++ b/frontend/plugin_init.rb
@@ -27,4 +27,12 @@ Rails.application.config.after_initialize do
     end
   end
 
+
+  SearchResultData.class_eval do
+    self.singleton_class.send(:alias_method, :BASE_FACETS_pre_component_report, :BASE_FACETS)
+    def self.BASE_FACETS
+      self.BASE_FACETS_pre_component_report << "level"
+    end
+  end
+
 end

--- a/indexer/indexer.rb
+++ b/indexer/indexer.rb
@@ -1,0 +1,14 @@
+class CommonIndexer
+
+  add_indexer_initialize_hook do |indexer|
+
+    indexer.add_document_prepare_hook {|doc, record|
+      if record['record']['jsonmodel_type'] == 'archival_object'
+        level = record['record']['level_display_string']
+        doc['title'] = [doc['title'], level].compact.join(", ")
+      end
+    }
+
+  end
+
+end

--- a/schemas/archival_object_ext.rb
+++ b/schemas/archival_object_ext.rb
@@ -1,0 +1,6 @@
+{
+  "level_display_string" => {
+    "type" => "string",
+    "readonly" => "true",
+  }
+}


### PR DESCRIPTION
Some initial investigation...
1. By adding `level` to the BASE_FACETS we surface level as a facet in the advanced and global search.
2. We can extend the Indexer and Archival Object to append the `level` when we index its `title`.  This displays in all search related interfaces including typeahead, global and advanced searches.

These are happily plugged!  Any other ideas?
