### PR TITLE
[Delivers #91441632] Generate an Excel spreadsheet from the items selected

### DIFF
--- a/backend/controllers/component_report.rb
+++ b/backend/controllers/component_report.rb
@@ -20,7 +20,7 @@ class ArchivesSpaceService < Sinatra::Base
   .permissions([:view_repository])
   .returns([200, "report"]) \
   do
-    cart_resolved = resolve_references(Cart.new(params[:uri]).cart_items, ["resource","series", "box", "component"])
+    cart_resolved = resolve_references(Cart.new(params[:uri]).cart_items, ["resource","series", "box", "file", "item", "resource::linked_agents", "resource::container_locations", "box::container_locations"])
 
     [
       200,

--- a/backend/controllers/component_report.rb
+++ b/backend/controllers/component_report.rb
@@ -1,6 +1,6 @@
 class ArchivesSpaceService < Sinatra::Base
 
-  Endpoint.post('/plugins/component_report/repository/:repo_id/cart')
+  Endpoint.post('/plugins/component_report/repositories/:repo_id/cart')
   .description("Return resolved JSON of the records in the cart")
   .params(["repo_id", :repo_id],
           ["uri", [String], "The uris of the records in the cart"])
@@ -11,5 +11,26 @@ class ArchivesSpaceService < Sinatra::Base
 
     json_response(resolve_references(cart.cart_items, ["resource","series", "box", "file", "item"]))
   end
+
+
+  Endpoint.post('/plugins/component_report/repositories/:repo_id/report')
+  .description("Return Excel formatted component report for record uris")
+  .params(["repo_id", :repo_id],
+          ["uri", [String], "The uris of the records in the cart"])
+  .permissions([:view_repository])
+  .returns([200, "report"]) \
+  do
+    cart_resolved = resolve_references(Cart.new(params[:uri]).cart_items, ["resource","series", "box", "component"])
+
+    [
+      200,
+      {
+        "Content-Type" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "Content-Disposition" => "attachment; filename=\"component_report.xlsx\""
+      },
+      ComponentReport.new(cart_resolved).to_stream
+    ]
+  end
+
 
 end

--- a/backend/model/component_report.rb
+++ b/backend/model/component_report.rb
@@ -3,63 +3,63 @@ require 'axlsx'
 class ComponentReport
 
   RESOURCE_COLUMNS = [
-    {:header => "Resource Title",       :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Resource ID",          :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Agent Name (creator)", :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Resource Dates",       :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Location",             :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Resource Title",       :proc => Proc.new {|resource| record_title(resource)}},
+    {:header => "Resource ID",          :proc => Proc.new {|resource| resource_id(resource)}},
+    {:header => "Agent Name (creator)", :proc => Proc.new {|resource| resource_creator(resource)}},
+    {:header => "Resource Dates",       :proc => Proc.new {|resource| record_dates(resource)}},
+    {:header => "Location",             :proc => Proc.new {|resource| resource_locations(resource)}},
   ]
 
   SERIES_COLUMNS = [
-    {:header => "Resource Title",       :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Resource ID",          :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Agent Name (creator)", :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Series Title",         :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Series Dates",         :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Resource Title",       :proc => Proc.new {|resource, series| record_title(resource)}},
+    {:header => "Resource ID",          :proc => Proc.new {|resource, series| resource_id(resource)}},
+    {:header => "Agent Name (creator)", :proc => Proc.new {|resource, series| resource_creator(resource)}},
+    {:header => "Series Title",         :proc => Proc.new {|resource, series| record_title(series)}},
+    {:header => "Series Dates",         :proc => Proc.new {|resource, series| record_dates(series)}},
   ]
 
   BOX_COLUMNS = [
-    {:header => "Resource Title",       :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Resource ID",          :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Agent Name (creator)", :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Series Title",         :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Series Dates",         :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Box Title",            :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Box Dates",            :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Box Location",         :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Restrictions",         :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Resource Title",       :proc => Proc.new {|resource, series, box| record_title(resource)}},
+    {:header => "Resource ID",          :proc => Proc.new {|resource, series, box| resource_id(resource)}},
+    {:header => "Agent Name (creator)", :proc => Proc.new {|resource, series, box| resource_creator(resource)}},
+    {:header => "Series Title",         :proc => Proc.new {|resource, series, box| record_title(series)}},
+    {:header => "Series Dates",         :proc => Proc.new {|resource, series, box| record_dates(series)}},
+    {:header => "Box Title",            :proc => Proc.new {|resource, series, box| record_title(box)}},
+    {:header => "Box Dates",            :proc => Proc.new {|resource, series, box| record_dates(box)}},
+    {:header => "Box Location",         :proc => Proc.new {|resource, series, box| box_locations(box)}},
+    {:header => "Restrictions",         :proc => Proc.new {|resource, series, box| restrictions(resource, series, box)}},
   ]
 
   FILE_COLUMNS = [
-    {:header => "Resource Title",       :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Resource ID",          :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Agent Name (creator)", :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Series Title",         :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Series Dates",         :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Box Title",            :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Box Dates",            :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Box Location",         :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "File Title",           :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "File Date",            :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "File Scope/Content",   :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Restrictions",         :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Resource Title",       :proc => Proc.new {|resource, series, box, file| record_title(resource)}},
+    {:header => "Resource ID",          :proc => Proc.new {|resource, series, box, file| resource_id(resource)}},
+    {:header => "Agent Name (creator)", :proc => Proc.new {|resource, series, box, file| resource_creator(resource)}},
+    {:header => "Series Title",         :proc => Proc.new {|resource, series, box, file| record_title(series)}},
+    {:header => "Series Dates",         :proc => Proc.new {|resource, series, box, file| record_dates(series)}},
+    {:header => "Box Title",            :proc => Proc.new {|resource, series, box, file| record_title(box)}},
+    {:header => "Box Dates",            :proc => Proc.new {|resource, series, box, file| record_dates(box)}},
+    {:header => "Box Location",         :proc => Proc.new {|resource, series, box, file| box_locations(box)}},
+    {:header => "File Title",           :proc => Proc.new {|resource, series, box, file| record_title(file)}},
+    {:header => "File Date",            :proc => Proc.new {|resource, series, box, file| record_dates(file)}},
+    {:header => "File Scope/Content",   :proc => Proc.new {|resource, series, box, file| file_scope(file)}},
+    {:header => "Restrictions",         :proc => Proc.new {|resource, series, box, file| restrictions(resource, series, box, file)}},
   ]
 
   ITEM_COLUMNS = [
-    {:header => "Resource Title",       :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Resource ID",          :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Agent Name (creator)", :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Series Title",         :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Series Dates",         :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Box Title",            :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Box Dates",            :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Box Location",         :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "File Title",           :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "File Date",            :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "File Scope/Content",   :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Item Description",     :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Item Date",            :proc => Proc.new {|cart_item| "TODO"}},
-    {:header => "Restrictions",         :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Resource Title",       :proc => Proc.new {|resource, series, box, file, item| record_title(resource)}},
+    {:header => "Resource ID",          :proc => Proc.new {|resource, series, box, file, item| resource_id(resource)}},
+    {:header => "Agent Name (creator)", :proc => Proc.new {|resource, series, box, file, item| resource_creator(resource)}},
+    {:header => "Series Title",         :proc => Proc.new {|resource, series, box, file, item| record_title(series)}},
+    {:header => "Series Dates",         :proc => Proc.new {|resource, series, box, file, item| record_dates(series)}},
+    {:header => "Box Title",            :proc => Proc.new {|resource, series, box, file, item| record_title(box)}},
+    {:header => "Box Dates",            :proc => Proc.new {|resource, series, box, file, item| record_dates(box)}},
+    {:header => "Box Location",         :proc => Proc.new {|resource, series, box, file, item| box_locations(box)}},
+    {:header => "File Title",           :proc => Proc.new {|resource, series, box, file, item| record_title(file)}},
+    {:header => "File Date",            :proc => Proc.new {|resource, series, box, file, item| record_dates(file)}},
+    {:header => "File Scope/Content",   :proc => Proc.new {|resource, series, box, file, item| file_scope(file)}},
+    {:header => "Item Description",     :proc => Proc.new {|resource, series, box, file, item| record_title(item)}},
+    {:header => "Item Date",            :proc => Proc.new {|resource, series, box, file, item| record_dates(item)}},
+    {:header => "Restrictions",         :proc => Proc.new {|resource, series, box, file, item| restrictions(resource, series, box, file, item)}},
   ]
 
 
@@ -69,11 +69,25 @@ class ComponentReport
 
     @p = Axlsx::Package.new
     @wb = @p.workbook
+    @wb.use_shared_strings = true # fix newlines/wrapping in Mac Excel
+
+    @cell_style = @wb.styles.add_style alignment: {
+      wrap_text: true,
+      vertical: :top
+    }
 
     build_report
   end
 
   def to_stream
+    @resources_ws.to_xml_string
+    @series_ws.to_xml_string
+    @boxes_ws.to_xml_string
+    @files_ws.to_xml_string
+    @items_ws.to_xml_string
+
+    #For testing, serialize report to a file
+    #@p.serialize("testing.xlsx")
     @p.to_stream
   end
 
@@ -111,12 +125,141 @@ class ComponentReport
   end
 
 
+  # Add the cart item to the correct worksheet
   def add_cart_item_to_report(cart_item)
-    @resources_ws.add_row(RESOURCE_COLUMNS.map {|col| col[:proc].call(cart_item)})
-    @series_ws.add_row(SERIES_COLUMNS.map {|col| col[:proc].call(cart_item)})
-    @boxes_ws.add_row(BOX_COLUMNS.map {|col| col[:proc].call(cart_item)})
-    @files_ws.add_row(FILE_COLUMNS.map {|col| col[:proc].call(cart_item)})
-    @items_ws.add_row(ITEM_COLUMNS.map {|col| col[:proc].call(cart_item)})
+    add_item(cart_item) || add_file(cart_item) || add_box(cart_item) || add_series(cart_item) || add_resource(cart_item)
   end
 
+
+  def add_item(cart_item)
+    cart_item['item'] && @items_ws.add_row(ITEM_COLUMNS.map {|col| col[:proc].call(cart_item['resource']['_resolved'], cart_item['series']['_resolved'], cart_item['box']['_resolved'], cart_item['file']['_resolved'], cart_item['item']['_resolved'])}, style: @cell_style)
+  end
+
+
+  def add_file(cart_item)
+    cart_item['file'] && @files_ws.add_row(FILE_COLUMNS.map {|col| col[:proc].call(cart_item['resource']['_resolved'], cart_item['series']['_resolved'], cart_item['box']['_resolved'], cart_item['file']['_resolved'])}, style: @cell_style)
+  end
+
+
+  def add_box(cart_item)
+    cart_item['box'] && @boxes_ws.add_row(BOX_COLUMNS.map {|col| col[:proc].call(cart_item['resource']['_resolved'], cart_item['series']['_resolved'], cart_item['box']['_resolved'])}, style: @cell_style)
+  end
+
+
+  def add_series(cart_item)
+    cart_item['series'] && @series_ws.add_row(SERIES_COLUMNS.map {|col| col[:proc].call(cart_item['resource']['_resolved'], cart_item['series']['_resolved'])}, style: @cell_style)
+  end
+
+
+  def add_resource(cart_item)
+    cart_item['resource'] && @resources_ws.add_row(RESOURCE_COLUMNS.map {|col| col[:proc].call(cart_item['resource']['_resolved'])}, style: @cell_style)
+  end
+
+
+  # Cell value generators
+  def self.record_title(record)
+    record['title']
+  end
+
+
+  def self.resource_id(resource)
+    (0..3).map {|i| resource["id_#{i}"]}.compact.join(".")
+  end
+
+
+  def self.resource_creator(resource)
+    resource['linked_agents'].map{|agent|
+      agent['_resolved']['title'].strip if agent['role'] == "creator"
+    }.compact.join(", ")
+  end
+
+
+  def self.record_dates(record)
+    record['dates'].map{|date|
+      date_string = I18n.t("enumerations.date_label.#{date['label']}", :default => date['label'])
+      date_string << ": "
+      if date['expression']
+        date_string << date['expression']
+      elsif date['date_type'] == 'single'
+        date_string << date['begin']
+      else
+        date_string << "#{date['begin']} - #{date['end']}"
+      end
+    }.join(", ")
+  end
+
+
+  def self.resource_locations(resource)
+    # (Location: Instance 1, Container 1 Indicator)
+    container_instances = resource['instances'].map{|inst| inst if inst['container']}.compact
+
+    container_instances.map{|instance|
+      container = instance['container']
+      current_location = ASUtils.as_array(container['container_locations']).find{|cl| cl['status'] == 'current'}
+
+      location_display_string = current_location.nil? ? "No Location" : current_location['_resolved']['title']
+      container_display_string = container['indicator_1']
+
+      "#{location_display_string}: #{container_display_string}"
+    }.join("; ")
+  end
+
+
+  def self.box_locations(box)
+    # (Location: Area, Coord Ind 1, Coord Ind 2, Coord Ind 3)
+    container_instances = box['instances'].map{|inst| inst if inst['container']}.compact
+
+    container_instances.map{|instance|
+      container = instance['container']
+      current_location = ASUtils.as_array(container['container_locations']).find{|cl| cl['status'] == 'current'}
+
+      current_location.nil? ? "No Location" : current_location['_resolved']['title']
+    }.join("; ")
+  end
+
+  NEWLINE = "\x0D\x0A"
+  def self.restrictions(*records)
+    restrictions_per_note_type = []
+    notes = {}
+
+    ASUtils.as_array(records).each{|record|
+      record['notes'].each{ |note|
+        notes[note['type']] ||= []
+        notes[note['type']] << note
+      }
+    }
+
+    if notes["accessrestrict"]
+      summary = "#{I18n.t("enumerations.note_multipart_type.accessrestrict")}:#{NEWLINE}"
+      summary += notes["accessrestrict"].map{|note|
+        ASUtils.as_array(note['subnotes']).map{|subnote| subnote['content']}.compact
+      }.flatten.uniq.join(NEWLINE)
+
+      restrictions_per_note_type << summary
+    end
+
+
+    if notes["userestrict"]
+      summary = "#{I18n.t("enumerations.note_multipart_type.userestrict")}:#{NEWLINE}"
+
+      summary += notes["userestrict"].map{|note|
+        ASUtils.as_array(note['subnotes']).map{|subnote| subnote['content']}.compact
+      }.flatten.uniq.join(NEWLINE)
+
+      restrictions_per_note_type << summary
+    end
+
+    restrictions_per_note_type.join(NEWLINE+NEWLINE)
+  end
+
+
+  def self.file_scope(file)
+    # File Scope/Content (note of type scopecontent)
+    subnotes = ASUtils.as_array(file['notes']).map{|note|
+      note['subnotes'] if note['type'] == "scopecontent"
+    }.compact.flatten
+    subnotes.map{|subnote|
+      subnote['content']
+    }.compact.join(NEWLINE)
+  end
 end

--- a/backend/model/component_report.rb
+++ b/backend/model/component_report.rb
@@ -1,0 +1,122 @@
+require 'axlsx'
+
+class ComponentReport
+
+  RESOURCE_COLUMNS = [
+    {:header => "Resource Title",       :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Resource ID",          :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Agent Name (creator)", :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Resource Dates",       :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Location",             :proc => Proc.new {|cart_item| "TODO"}},
+  ]
+
+  SERIES_COLUMNS = [
+    {:header => "Resource Title",       :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Resource ID",          :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Agent Name (creator)", :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Series Title",         :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Series Dates",         :proc => Proc.new {|cart_item| "TODO"}},
+  ]
+
+  BOX_COLUMNS = [
+    {:header => "Resource Title",       :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Resource ID",          :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Agent Name (creator)", :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Series Title",         :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Series Dates",         :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Box Title",            :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Box Dates",            :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Box Location",         :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Restrictions",         :proc => Proc.new {|cart_item| "TODO"}},
+  ]
+
+  FILE_COLUMNS = [
+    {:header => "Resource Title",       :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Resource ID",          :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Agent Name (creator)", :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Series Title",         :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Series Dates",         :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Box Title",            :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Box Dates",            :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Box Location",         :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "File Title",           :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "File Date",            :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "File Scope/Content",   :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Restrictions",         :proc => Proc.new {|cart_item| "TODO"}},
+  ]
+
+  ITEM_COLUMNS = [
+    {:header => "Resource Title",       :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Resource ID",          :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Agent Name (creator)", :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Series Title",         :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Series Dates",         :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Box Title",            :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Box Dates",            :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Box Location",         :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "File Title",           :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "File Date",            :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "File Scope/Content",   :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Item Description",     :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Item Date",            :proc => Proc.new {|cart_item| "TODO"}},
+    {:header => "Restrictions",         :proc => Proc.new {|cart_item| "TODO"}},
+  ]
+
+
+
+  def initialize(cart)
+    @cart = cart
+
+    @p = Axlsx::Package.new
+    @wb = @p.workbook
+
+    build_report
+  end
+
+  def to_stream
+    @p.to_stream
+  end
+
+  private
+
+  def build_report
+    add_empty_worksheets_with_headers
+
+    @cart.each do |cart_item|
+      add_cart_item_to_report(cart_item)
+    end
+  end
+
+
+  def add_empty_worksheets_with_headers
+    # resources
+    @resources_ws = @wb.add_worksheet(:name => "Resources")
+    @resources_ws.add_row(RESOURCE_COLUMNS.map{|col| col[:header]})
+
+    # series
+    @series_ws = @wb.add_worksheet(:name => "Series")
+    @series_ws.add_row(SERIES_COLUMNS.map{|col| col[:header]})
+
+    # boxes
+    @boxes_ws = @wb.add_worksheet(:name => "Boxes")
+    @boxes_ws.add_row(BOX_COLUMNS.map{|col| col[:header]})
+
+    # files
+    @files_ws = @wb.add_worksheet(:name => "Files")
+    @files_ws.add_row(FILE_COLUMNS.map{|col| col[:header]})
+
+    # items
+    @items_ws = @wb.add_worksheet(:name => "Items")
+    @items_ws.add_row(ITEM_COLUMNS.map{|col| col[:header]})
+  end
+
+
+  def add_cart_item_to_report(cart_item)
+    @resources_ws.add_row(RESOURCE_COLUMNS.map {|col| col[:proc].call(cart_item)})
+    @series_ws.add_row(SERIES_COLUMNS.map {|col| col[:proc].call(cart_item)})
+    @boxes_ws.add_row(BOX_COLUMNS.map {|col| col[:proc].call(cart_item)})
+    @files_ws.add_row(FILE_COLUMNS.map {|col| col[:proc].call(cart_item)})
+    @items_ws.add_row(ITEM_COLUMNS.map {|col| col[:proc].call(cart_item)})
+  end
+
+end

--- a/backend/model/component_report.rb
+++ b/backend/model/component_report.rb
@@ -80,12 +80,6 @@ class ComponentReport
   end
 
   def to_stream
-    @resources_ws.to_xml_string
-    @series_ws.to_xml_string
-    @boxes_ws.to_xml_string
-    @files_ws.to_xml_string
-    @items_ws.to_xml_string
-
     #For testing, serialize report to a file
     #@p.serialize("testing.xlsx")
     @p.to_stream

--- a/frontend/assets/search_cart.checkout.js
+++ b/frontend/assets/search_cart.checkout.js
@@ -14,7 +14,7 @@ CartCheckout.prototype.loadCart = function() {
   this.cart.loadCart(this.$cartData);
 
   this.$container.on("click", "#generateReportFromCart", function() {
-    alert("Next on the list!");
+    $("#componentReportForm").trigger("submit");
   });
 };
 

--- a/frontend/assets/search_cart.js
+++ b/frontend/assets/search_cart.js
@@ -260,11 +260,18 @@ Cart.prototype.setupTreePageActions = function() {
   };
 
   function setupTreeToolbar(event) {
+    var $node = $(".primary-selected", $tree);
+
+    if ($node.hasClass("new")) {
+      // nothing to do as item is new
+      return;
+    }
+
+    var uri = uriForNode($node);
+
     var actions = AS.renderTemplate("template_cart_actions");
     $toolbar.find(".btn-toolbar").append(actions);
 
-    var $node = $(".primary-selected", $tree);
-    var uri = uriForNode($node);
     toggleCartActions(uri);
   };
 

--- a/frontend/controllers/cart_controller.rb
+++ b/frontend/controllers/cart_controller.rb
@@ -1,6 +1,7 @@
 class CartController < ApplicationController
 
-  set_access_control  "view_repository" => [:checkout, :summary]
+  set_access_control  "view_repository" => [:checkout, :summary, :download_report]
+
 
   def checkout
   end
@@ -11,12 +12,90 @@ class CartController < ApplicationController
     if uris.empty?
       @cart_items = []
     else
-      response = JSONModel::HTTP.post_form("/plugins/component_report/repository/#{session[:repo_id]}/cart", "uri[]" => uris)
+      response = JSONModel::HTTP.post_form("/plugins/component_report/repositories/#{session[:repo_id]}/cart", "uri[]" => uris)
       @cart_items = ASUtils.json_parse(response.body)
     end
 
     render_aspace_partial :partial => "cart/summary"
   end
 
-end
 
+  def download_report
+    uris = ASUtils.as_array(params[:uri])
+
+    queue = Queue.new
+
+    backend_session = JSONModel::HTTP::current_backend_session
+
+    Thread.new do
+      JSONModel::HTTP::current_backend_session = backend_session
+      begin
+        post_with_stream_response("/plugins/component_report/repositories/#{session[:repo_id]}/report", "uri[]" => uris) do |report_response|
+          response.headers['Content-Disposition'] = report_response['Content-Disposition']
+          response.headers['Content-Type'] = report_response['Content-Type']
+          response.headers['Last-Modified'] = Time.now.to_s
+          response.headers['Cache-Control'] = 'no-cache'
+          response.headers['X-Content-Type-Options'] = 'nosniff'
+
+          queue << :ok
+          report_response.read_body do |chunk|
+            queue << chunk
+          end
+        end
+      rescue
+        queue << {:error => $!.message}
+      ensure
+        queue << :EOF
+      end
+    end
+
+    first_on_queue = queue.pop # :ok or error hash
+    if first_on_queue.kind_of?(Hash)
+      @report_errors = first_on_queue[:error]
+
+      return render :action => :checkout
+    end
+
+    self.response_body = Class.new do
+      def self.queue=(queue)
+        @queue = queue
+      end
+      def self.each(&block)
+        while(true)
+          chunk = @queue.pop
+
+          break if chunk === :EOF
+
+          block.call(chunk)
+        end
+      end
+    end
+
+    self.response_body.queue = queue
+  end
+
+
+  private
+
+
+  def post_with_stream_response(uri, params = {}, &block)
+    uri = URI("#{ JSONModel::backend_url}#{uri}")
+    uri.query = URI.encode_www_form(params)
+
+    req = Net::HTTP::Post.new(uri.request_uri)
+
+    req['X-ArchivesSpace-Session'] = JSONModel::HTTP::current_backend_session
+
+    Net::HTTP.start(uri.host, uri.port) do |http|
+      http.request(req, nil) do |response|
+        if response.code =~ /^4/
+          JSONModel::handle_error(ASUtils.json_parse(response.body))
+          raise response.body
+        end
+
+        block.call(response)
+      end
+    end
+  end
+
+end

--- a/frontend/routes.rb
+++ b/frontend/routes.rb
@@ -1,4 +1,5 @@
 ArchivesSpace::Application.routes.draw do
   match('/plugins/component_report/checkout' => 'cart#checkout', :via => [:get])
   match('/plugins/component_report/summary' => 'cart#summary', :via => [:post])
+  match('/plugins/component_report/download_report' => 'cart#download_report', :via => [:post])
 end

--- a/frontend/views/cart/_summary.html.erb
+++ b/frontend/views/cart/_summary.html.erb
@@ -27,6 +27,7 @@
           <td class="component-report-summary-file-title"><%= cart_item["file"]["_resolved"]["display_string"] rescue "" %></td>
           <td class="component-report-summary-item-title"><%= cart_item["item"]["_resolved"]["display_string"] rescue "" %></td>
           <td class="component-report-summary-actions">
+            <%= hidden_field_tag "uri[]", cart_item["selected"]["ref"] %>
             <div class="btn-group">
               <a href="<%= url_for :controller => :resolver, :action => :resolve_readonly, :uri => cart_item["selected"]["ref"] %>" class="btn btn-xs btn-default">View</a>
               <button class="btn btn-xs btn-warning remove-from-cart-btn" data-uri="<%= cart_item["selected"]["ref"] %>">

--- a/frontend/views/cart/checkout.html.erb
+++ b/frontend/views/cart/checkout.html.erb
@@ -8,13 +8,20 @@
 
       <h2><%= I18n.t("cart.checkout") %></h2>
 
+      <% if @report_errors %>
+        <pre><%= @report_errors.inspect %></pre>
+      <% end %>
+
       <%= render_aspace_partial :partial => "shared/flash_messages" %>
 
-      <div id="cartData" data-load-url="<%= url_for :controller => :cart, :action => :summary %>">
-        <div class="alert alert-info">
-          <%= I18n.t("cart.loading") %>
+      <%= form_tag(url_for(:controller => :cart, :action => :download_report), :method => :post, :id => "componentReportForm") do -%>
+        <div id="cartData" data-load-url="<%= url_for :controller => :cart, :action => :summary %>">
+          <div class="alert alert-info">
+            <%= I18n.t("cart.loading") %>
+          </div>
         </div>
-      </div>
+      <% end %>
+
 
     </div>
   </div>


### PR DESCRIPTION
This is my first go at generating a spreadsheet from the cart items.  The details of the report are specified in pivotal: https://www.pivotaltracker.com/story/show/91441632

Basically there are 5 work sheets, one for resources, series, boxes, files and items.  Each work sheet has different columns and a cart item will be added to their corresponding worksheet.

If having a play, unfortunately there's a bug in Puma that won't allow the full report to be downloaded when using a devserver (Puma doesn't like chunked responses).  It works in the distributed version nicely.   Alternatively, you can uncomment the line:

```
 #For testing, serialize report to a file
 @p.serialize("testing.xlsx")
```

which will output the report to your `ASPACE/backend` directory.

I've also fixed a bug where the "Add Cart" action was being displayed on the archival object form for new records.. I now check that the record has been created before displaying.
