### PR TITLE
Bring search listing template override into line with v1.3.0

### DIFF
--- a/frontend/views/search/_listing.html.erb
+++ b/frontend/views/search/_listing.html.erb
@@ -1,4 +1,5 @@
 <% if @search_data.results? %>
+  <% add_identifier_column if show_identifier_column? %>
   <%= render_aspace_partial :partial => "shared/pagination_summary" %>
 
   <table id="tabledSearchResults" class="table table-striped table-bordered table-condensed table-hover table-sortable table-search-results" <% if allow_multi_select? %>data-multiselect="true"<% end %>>


### PR DESCRIPTION
Bring in diff from v1.3.0 to v1.2.0 to ensure template overrides are up to date.
